### PR TITLE
Add TypeScript Definitons

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Emit latest event to new observers",
   "main": "dist/hold.js",
+  "typings": "type-definitions/hold.d.ts",
   "files": [
     "dist/hold.js"
   ],

--- a/type-definitions/hold.d.ts
+++ b/type-definitions/hold.d.ts
@@ -1,0 +1,3 @@
+import {Stream} from "most";
+
+export default function hold<A>(stream: Stream<A>): Stream<A>;


### PR DESCRIPTION
Adds a TypeScript definition for the single function provided.
Depends on `most` having Type Definitions. Probably shouldn't merge until this is actually true.