### PR TITLE
Update to most 0.19.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .idea/
+coverage/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "npm run build-dist && uglifyjs dist/hold.js -o dist/hold.min.js",
     "prepublish": "npm run build",
     "preversion": "npm run build",
-    "unit-test": "mocha --recursive -r babel-register",
+    "unit-test": "babel-node ./node_modules/.bin/isparta cover _mocha",
     "lint": "jsinspect src && jsinspect test && eslint src test",
     "test": "npm run lint && npm run unit-test"
   },
@@ -41,6 +41,7 @@
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
+    "isparta": "^4.0.0",
     "jsinspect": "^0.8.0",
     "mocha": "^2.4.5",
     "most": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "license": "MIT",
   "devDependencies": {
     "@most/eslint-config-most": "^1.0.2",
-    "@most/multicast": "^1.0.3",
     "assert": "^1.3.0",
     "babel-cli": "^6.2.4",
     "babel-core": "^6.2.4",
@@ -44,15 +43,14 @@
     "eslint-plugin-standard": "^1.3.2",
     "jsinspect": "^0.8.0",
     "mocha": "^2.4.5",
-    "most": "^0.18.0",
+    "most": "^0.19.0",
     "rollup": "^0.20.5",
     "uglify-js": "^2.6.0"
   },
   "peerDependencies": {
-    "@most/multicast": "^1.0.1",
-    "most": "^0.18.0"
+    "most": "^0.19.0"
   },
   "dependencies": {
-    "@most/multicast": "^1.0.3"
+    "@most/multicast": "^1.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ class Hold {
   }
 
   run (sink, scheduler) {
+    /* istanbul ignore else */
     if (sink._hold !== this) {
       sink._hold = this
       sink._holdAdd = sink.add
@@ -30,6 +31,7 @@ class Hold {
 
 function holdAdd (sink) {
   const len = this._holdAdd(sink)
+  /* istanbul ignore else */
   if (this._hold.time >= 0) {
     sink.event(this._hold.time, this._hold.value)
   }
@@ -37,6 +39,7 @@ function holdAdd (sink) {
 }
 
 function holdEvent (t, x) {
+  /* istanbul ignore else */
   if (t >= this._hold.time) {
     this._hold.time = t
     this._hold.value = x


### PR DESCRIPTION
Update deps.

### Open questions:

1. [ ] We had listed `@most/multicast` as both a dependency and a peerDependency which seems completely redundant in any version of npm.  I removed the peerDep, since `@most/hold` explicitly imports `@most/multicast`.  Does that seem right?