### PR TITLE
feat(hold): flush pending events

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "npm run build:dist && npm run build:min && npm run build:flow",
     "build:dist": "rollup -c",
     "build:min": "uglifyjs dist/index.js -m -o dist/index.min.js",
-    "build:flow": "cpy src/index.js.flow dist --rename=index.js.flow",
+    "build:flow": "cpy src/index.js dist --rename=index.js.flow",
     "prepublish": "npm run build"
   },
   "keywords": [
@@ -35,14 +35,19 @@
   "license": "MIT",
   "devDependencies": {
     "@briancavalier/assert": "^3.4.0",
+    "babel-eslint": "^8.0.1",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-flow": "^6.23.0",
     "buba": "^4.0.1",
     "cpy-cli": "^1.0.1",
-    "flow-bin": "^0.55.0",
+    "eslint-plugin-flowtype": "^2.37.0",
+    "flow-bin": "^0.56.0",
     "jsinspect": "^0.12.7",
     "mocha": "^3.5.3",
     "nyc": "^11.2.1",
     "rollup": "^0.50.0",
     "rollup-plugin-buble": "^0.15.0",
+    "rollup-plugin-flow": "^1.1.1",
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",
     "uglify-js": "^3.1.1"
@@ -51,5 +56,17 @@
     "@most/core": "^0.13.0",
     "@most/scheduler": "^0.13.0",
     "@most/types": "^0.11.1"
+  },
+  "babel": {
+    "presets": [
+      "env",
+      "flow"
+    ]
+  },
+  "standard": {
+    "parser": "babel-eslint",
+    "plugins": [
+      "flowtype"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "npm run test:lint && npm run test:unit && npm run test:flow",
-    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
+    "test:unit": "nyc mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
     "test:lint": "jsinspect src/*.js test/*.js && standard --fix 'src/**/*.js' 'test/**/*.js' --verbose | snazzy",
     "test:flow": "flow check",
     "build": "npm run build:dist && npm run build:min && npm run build:flow",
@@ -35,7 +35,6 @@
   "license": "MIT",
   "devDependencies": {
     "@briancavalier/assert": "^3.4.0",
-    "@most/scheduler": "^0.13.0",
     "buba": "^4.0.1",
     "cpy-cli": "^1.0.1",
     "flow-bin": "^0.55.0",
@@ -50,6 +49,7 @@
   },
   "dependencies": {
     "@most/core": "^0.13.0",
+    "@most/prelude": "^1.6.4",
     "@most/types": "^0.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "npm run test:lint && npm run test:unit && npm run test:flow",
-    "test:unit": "nyc mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
+    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
     "test:lint": "jsinspect src/*.js test/*.js && standard --fix 'src/**/*.js' 'test/**/*.js' --verbose | snazzy",
     "test:flow": "flow check",
     "build": "npm run build:dist && npm run build:min && npm run build:flow",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@most/core": "^0.13.0",
-    "@most/prelude": "^1.6.4",
+    "@most/scheduler": "^0.13.0",
     "@most/types": "^0.11.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,14 @@
 import buble from 'rollup-plugin-buble'
+import flow from 'rollup-plugin-flow'
 import pkg from './package.json'
 
 export default {
   input: 'src/index.js',
   plugins: [
+    flow(),
     buble()
   ],
-  external: ['@most/core'],
+  external: ['@most/core', '@most/scheduler'],
   output: [
     {
       file: pkg.main,
@@ -14,7 +16,8 @@ export default {
       name: 'mostHold',
       sourcemap: true,
       globals: {
-        '@most/core': 'mostCore'
+        '@most/core': 'mostCore',
+        '@most/scheduler': 'mostScheduler'
       }
     },
     {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { MulticastSource } from '@most/core'
-import { asap } from '@most/scheduler'
+import { asap, cancelTask } from '@most/scheduler'
 
 export const hold = stream =>
   new Hold(stream)
@@ -53,8 +53,7 @@ export class Hold extends MulticastSource {
 
   _cancelTask () {
     if (this.task) {
-      console.log(this.task.cancel, this.task.dispose)
-      this.task.dispose()
+      cancelTask(this.task)
       this.task = undefined
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ export class Hold extends MulticastSource {
   _scheduleFlush (sink, scheduler) {
     this.pendingSinks.push(sink)
     if (!this.task) {
-      this._cancelTask()
+      cancelTask(this.task)
       this.task = asap(new HoldTask(this), scheduler)
     }
   }
@@ -85,7 +85,7 @@ class HoldTask {
   dispose () {}
 }
 
-export function tryEvent (t, x, sink) {
+function tryEvent (t, x, sink) {
   try {
     sink.event(t, x)
   } catch (e) {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,4 +1,0 @@
-// @flow
-import type { Stream } from '@most/types'
-
-declare export function hold <A> (s: Stream<A>): Stream<A>

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -6,10 +6,10 @@ import { newDefaultScheduler, delay } from '@most/scheduler'
 import { hold } from '../src/index'
 
 const collect = (stream, scheduler) => {
-  const into = []
-  const collectStream = tap(x => into.push(x), stream)
+  const eventValues = []
+  const collectStream = tap(x => eventValues.push(x), stream)
   return runEffects(collectStream, scheduler)
-    .then(() => into)
+    .then(() => eventValues)
 }
 
 const verifyHold = f => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,20 +1,58 @@
 import { describe, it } from 'mocha'
-import { eq } from '@briancavalier/assert'
-import { at, chain, mergeArray, runEffects, take, tap } from '@most/core'
+import { eq, assert } from '@briancavalier/assert'
+import { at, mergeArray, runEffects, take, tap } from '@most/core'
+import { newDefaultScheduler, delay } from '@most/scheduler'
 import { hold } from '../src/index'
-import { newDefaultScheduler } from '@most/scheduler'
 
-export const drain = s => runEffects(s, newDefaultScheduler())
-
-export const collect = s => {
+const collect = (stream, scheduler) => {
   const into = []
-  return drain(tap(x => into.push(x), s)).then(() => into)
+  const collectStream = tap(x => into.push(x), stream)
+  return runEffects(collectStream, scheduler)
+    .then(() => into)
+}
+
+const verifyHold = f => {
+  const scheduler = newDefaultScheduler()
+  const s = hold(mergeArray([at(0, 0), at(10, 1), at(20, 2)]))
+
+  const p0 = collect(take(1, s), scheduler)
+    .then(eq([0]))
+
+  const p1 = f(s, scheduler)
+
+  return Promise.all([p0, p1])
 }
 
 describe('hold', () => {
   it('should deliver most recent event to new observer', () => {
-    const s = hold(mergeArray([at(0, 0), at(1, 1), at(2, 2)]))
-    return collect(chain(_ => s, take(1, s)))
-      .then(eq([0, 1, 2]))
+    return verifyHold((stream, scheduler) => {
+      return new Promise((resolve, reject) => {
+        delay(5, {
+          run (t) {
+            resolve(collect(stream, scheduler))
+          },
+          error (t, e) {
+            reject(e)
+          }
+        }, scheduler)
+      }).then(eq([0, 1, 2]))
+    })
+  })
+
+  it(`should not propagate held event during the same tick as run`, () => {
+    return verifyHold((stream, scheduler) => {
+      return new Promise((resolve, reject) => {
+        delay(5, {
+          run (t) {
+            let called = false
+            runEffects(tap(_ => { called = true }, stream), scheduler)
+            resolve(assert(!called))
+          },
+          error (t, e) {
+            reject(e)
+          }
+        }, scheduler)
+      })
+    })
   })
 })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,3 +1,4 @@
+// @flow
 import { describe, it } from 'mocha'
 import { eq, assert } from '@briancavalier/assert'
 import { at, mergeArray, runEffects, take, tap } from '@most/core'
@@ -16,7 +17,7 @@ const verifyHold = f => {
   const s = hold(mergeArray([at(0, 0), at(10, 1), at(20, 2)]))
 
   const p0 = collect(take(1, s), scheduler)
-    .then(eq([0]))
+    .then(events => eq([0], events))
 
   const p1 = f(s, scheduler)
 
@@ -33,9 +34,10 @@ describe('hold', () => {
           },
           error (t, e) {
             reject(e)
-          }
+          },
+          dispose () {}
         }, scheduler)
-      }).then(eq([0, 1, 2]))
+      }).then(events => eq([0, 1, 2], events))
     })
   })
 
@@ -50,7 +52,8 @@ describe('hold', () => {
           },
           error (t, e) {
             reject(e)
-          }
+          },
+          dispose () {}
         }, scheduler)
       })
     })

--- a/type-definitions/hold.d.ts
+++ b/type-definitions/hold.d.ts
@@ -1,3 +1,3 @@
-import {Stream, Source, Sink, Scheduler, Disposable} from "most";
+import { Stream } from "@most/types";
 
 export function hold<A>(stream: Stream<A>): Stream<A>;


### PR DESCRIPTION
Similar to #24

This buffers new sinks, and sets up a race to flush the held event between an asap task and the next event.

The idea in this PR is to place newly arrived sinks into a pendingSinks array, separate from the normal sinks array, and race 2 things which will always result in the held event being delivered to all pending sinks, as well as move all those pending sinks to the regular sinks array.  The race is between an asap task scheduled when a sink arrives and any new event that arrives after the task was scheduled, but before it executes.

One of these must happen first: the task will execute, or an event will arrive.  In either case, the held event will be delivered to all pendingSinks, and events can continue to be delivered _synchronously_.  That's important: this strategy avoids the need to asap() every event.

1. When the asap task wins the race, the held event will be delivered to all pendingSinks, and all pendingSinks are _moved_ to the sinks array.   If an event arrives after that, it can be delivered synchronously to all the sinks.

2. When a new event wins the race, the held event will be delivered to all pendingSinks, and all pendingSinks are _moved_ to the sinks array.  Then, the new event is delivered immediately and synchronously to all sinks.  Again, subsequent events can be delivered synchronously.