### PR TITLE
Fix pending sink double add

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 coverage/
 .nyc_output/
 dist/
+experiments/

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,7 +1,7 @@
 // @flow
 import { describe, it } from 'mocha'
 import { eq, assert } from '@briancavalier/assert'
-import { at, mergeArray, runEffects, take, tap } from '@most/core'
+import { at, mergeArray, merge, join, map, periodic, runEffects, scan, take, tap } from '@most/core'
 import { newDefaultScheduler, delay } from '@most/scheduler'
 import { hold } from '../src/index'
 
@@ -57,5 +57,19 @@ describe('hold', () => {
         }, scheduler)
       })
     })
+  })
+
+  it('should produce expected events', () => {
+    const scheduler = newDefaultScheduler()
+
+    let testHold = hold(scan(x => x + 1, 0, periodic(2)))
+
+    // s1 should see 0 - 4
+    const s1 = map(x => `s1${x}`, take(5, testHold))
+    // s2 should see 2 - 6
+    const s2 = map(x => `s2${x}`, join(at(2, take(5, testHold))))
+
+    return collect(merge(s1, s2), scheduler)
+      .then(events => eq(['s10', 's11', 's12', 's22', 's13', 's23', 's14', 's24', 's25', 's26'], events))
   })
 })


### PR DESCRIPTION
Fix #31 

Pending sinks were being added to `this.sinks` twice.  This fixes the issue, and passes the example in #31.

### Todo

- [x] Add regression test based on example in #31.