### PR TITLE
fix(hold): fix most recent event devlivery for late observers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "test": "npm run test:lint && npm run test:unit && npm run test:flow",
-    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot --recursive 'test/**/*-test.js'",
-    "test:lint": "jsinspect src/*.js test/*.js && standard --fix 'src/**/*.js' 'test/**/*.js'",
+    "test:unit": "nyc --reporter=text-summary mocha -r buba/register --reporter dot --recursive ./test/**/*-test.js",
+    "test:lint": "jsinspect ./src ./test && standard --fix 'src/**/*.js' 'test/**/*.js'",
     "test:flow": "flow check",
     "build": "npm run build:dist && npm run build:min && npm run build:flow",
     "build:dist": "rollup -c",

--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,8 @@ class Hold<A> extends MulticastSource<A> {
     this.pendingSinks.push(sink)
     if (this.task) {
       cancelTask(this.task)
-      this.task = asap(new HoldTask(this), scheduler)
     }
+    this.task = asap(new HoldTask(this), scheduler)
   }
 
   _cancelTask (): void {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,7 +1,19 @@
 import { describe, it } from 'mocha'
 import { eq, assert } from '@briancavalier/assert'
-import { at, mergeArray, merge, join, map, periodic, runEffects, scan, take, tap, propagateEventTask } from '@most/core'
-import { newDefaultScheduler, delay, asap } from '@most/scheduler'
+import {
+  at,
+  mergeArray,
+  merge,
+  join,
+  map,
+  periodic,
+  runEffects,
+  scan,
+  take,
+  tap,
+  now
+} from '@most/core'
+import { newDefaultScheduler, delay } from '@most/scheduler'
 import { hold } from '../src/index'
 
 const collect = (stream, scheduler) => {
@@ -44,12 +56,8 @@ describe('hold', () => {
 
   it('should deliver most recent event from hot source to late observers ', () => {
     const scheduler = newDefaultScheduler()
-    class HotProducer {
-      run (sink, scheduler) {
-        return asap(propagateEventTask('foo', sink), scheduler)
-      }
-    }
-    const source = hold(new HotProducer())
+    const value = 'foo'
+    const source = hold(now(value))
     const events = []
     const collectSink = {
       event: (time, value) => events.push(value),
@@ -63,9 +71,9 @@ describe('hold', () => {
     return delayPromise(10).then(() => {
       const s2 = source.run(collectSink, scheduler)
       return delayPromise(10).then(() => {
-        s1.dispose();
+        s1.dispose()
         s2.dispose()
-        return eq(events, ['foo', 'foo'])
+        return eq(events, [value, value])
       })
     })
   })

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -23,9 +23,8 @@ const collect = (stream, scheduler) => {
     .then(() => eventValues)
 }
 
-const scheduler = newDefaultScheduler()
-
 const verifyHold = f => {
+  const scheduler = newDefaultScheduler()
   const s = hold(mergeArray([at(0, 0), at(10, 1), at(20, 2)]))
 
   const p0 = collect(take(1, s), scheduler)
@@ -78,6 +77,7 @@ describe('hold', () => {
     }
 
     const test = (source, expected) => {
+      const scheduler = newDefaultScheduler()
       const events = []
       const sink = createCollectSink(events)
       const s1 = source.run(sink, scheduler)


### PR DESCRIPTION
Hi!

This PR fixes `hold` to schedule flush when new observer runs held hot source lately (after the first event from source was store in `hold` but before the source is disposed)