### PR TITLE
Demonstrate possible issue

### DIFF
--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -6,6 +6,7 @@ import { hold } from '../src'
 import { Scheduler, Sink, Stream, Time } from '@most/types'
 import {
   at,
+  combineArray,
   mergeArray,
   merge,
   join,
@@ -13,6 +14,7 @@ import {
   periodic,
   runEffects,
   scan,
+  switchLatest,
   take,
   tap,
   propagateEventTask
@@ -100,6 +102,23 @@ describe('hold', () => {
 
     it('should emit two events with hold for two observers', () => {
       return test(hold(new Source()), ['foo', 'foo'])
+    })
+
+    it('shall pass', () => {
+      const hos: Stream<Stream<string>[]> = scan(
+        (acc: Stream<string>[], _s: void) =>
+          acc.concat([hold(new Source())]),
+        [],
+        take(2, periodic(3))
+      )
+      const flat: Stream<string> = switchLatest(
+        map(arr => combineArray(
+          (...a: string[]) => a.join(' '),
+          arr
+        ), hos)
+      )
+
+      return test(flat, ['foo', 'foo foo'])
     })
   })
 


### PR DESCRIPTION
Hello and thank you for awesome library!

Recently I came across a use case that I thought was good fit for `hold`. Unfortunately it didn't work as expected. Before opening up the issue I thought that maybe I'll clarify what I do and what outcome I expect with a minimal test case.

I maintain an collection of streams (array in the example). Elements will come and go depending on the user interactions. That array is later combined to produce final result. I thought that each `combine` call is like creating a now observer for the held stream, however previous value isn't provided.

Is this how `hold` is suppose to work? Or did I actually found some issue here?