### PR TITLE
Add `MulticastStream` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,14 @@ import { Stream, Sink, ScheduledTask, Time, Scheduler, Disposable } from '@most/
 import { MulticastSource } from '@most/core'
 import { asap, cancelTask } from '@most/scheduler'
 
-export const hold = <A>(stream: Stream<A>): Stream<A> =>
+export interface MulticastStream<A> extends Stream<A> {}
+
+export const hold = <A>(stream: Stream<A>): MulticastStream<A> =>
   new Hold(stream)
 
 type HeldValue<A> = { value: A }
 
-class Hold<A> extends MulticastSource<A> implements Stream<A>, Disposable, Sink<A> {
+class Hold<A> extends MulticastSource<A> implements MulticastStream<A>, Disposable, Sink<A> {
   private pendingSinks: Sink<A>[] = []
   private held?: HeldValue<A> = undefined
   private task?: ScheduledTask = undefined


### PR DESCRIPTION
This commit adds a`MulticastStream` type. This type helps
developers to distinguish a held stream, i.e., an infinite stream,
from a non-held stream.

Knowing that a stream is multicast can prevent developers from
introducing timeouts, for example in tests, which are otherwise
hard to understand.

Signed-off-by: Frederik Krautwald <fkrautwald@gmail.com>